### PR TITLE
Switch to new getrawaddrman format

### DIFF
--- a/index.html
+++ b/index.html
@@ -51,15 +51,9 @@
             <ol class="list-group">
               <li class="list-group-item d-flex justify-content-between align-items-start">
                 <div>
-                  signet sample addrman (720kb)
+                  mainnet IPv4 and IPv6 sample addrman (14MB)
                 </div>
-                <button class="btn btn-outline-primary" onclick="loadFromURL('https://gist.githubusercontent.com/0xB10C/f2daea14ae0b0c06207a687e8b65202d/raw/befdba56adc0b3ce6cfdb9ceda70d276d5c2b2c3/getaddrmaninfo-signet.json')">load</button>
-              </li>
-              <li class="list-group-item d-flex justify-content-between align-items-start">
-                <div>
-                  mainnet IPv4 and IPv6 sample addrman (10MB)
-                </div>
-                <button class="btn btn-outline-primary" onclick="loadFromURL('https://gist.githubusercontent.com/0xB10C/f2daea14ae0b0c06207a687e8b65202d/raw/162d56f1cbcabb041c84283abfb12aa7f04bc501/getaddrmaninfo-mainnet.json')">load</button>
+                <button class="btn btn-outline-primary" onclick="loadFromURL('https://gist.githubusercontent.com/0xB10C/41aad0f94229172ee799e0948047266e/raw/d46f58f52c16b93857f8e72cba704cfc9f866d9d/mainnet.json')">load</button>
               </li>
             </ol>
           </div>

--- a/js/draw.js
+++ b/js/draw.js
@@ -13,31 +13,6 @@ const TRIED_BUCKETS_PER_BUCKET_COLUMN = 16;
 const NEW_HEIGHT = BUCKET_PIXEL_SIZE * NEW_BUCKETS_PER_BUCKET_COLUMN;
 const TRIED_HEIGHT = BUCKET_PIXEL_SIZE * TRIED_BUCKETS_PER_BUCKET_COLUMN;
 
-function address_network_type(addrinfo) {
-  if (addrinfo.address.includes("onion")) {
-    return "tor";
-  } else if (addrinfo.address.includes("internal")) {
-    return "internal";
-  } else if (addrinfo.address.includes("i2p")) {
-    return "i2p";
-  } else if (addrinfo.address.includes("[")) {
-    return "ipv6";
-  } else if (addrinfo.address.split(".").length == 4) {
-    return "ipv4";
-  }
-  return "unknown";
-}
-
-function port(addrinfo) {
-  return addrinfo.address.split(":").slice(-1);
-}
-
-function preprocess(addrinfo) {
-  addrinfo.port = port(addrinfo);
-  addrinfo.net_type = address_network_type(addrinfo);
-  return addrinfo;
-}
-
 network_to_color = {
   ipv4: d3.schemeDark2[0],
   ipv6: d3.schemeDark2[1],
@@ -265,7 +240,7 @@ function draw(is_zoom, tableState) {
         }
       } else {
         tableState.context.fillStyle =
-          network_to_color[address_network_type(addrInfo)];
+          network_to_color[addrInfo.network];
         tableState.context.fillRect(x, y, ADDR_PIXEL_SIZE, ADDR_PIXEL_SIZE); // x, y, width and height
       }
       position++;
@@ -279,10 +254,13 @@ function formatTooltip(addrinfo) {
   return `
     <table>
         <tr><td>address</td><td>${addrinfo.address}</td></tr>
-        <tr><td>network</td><td>${addrinfo.net_type}</td></tr>
-        <tr><td>source</td><td>${addrinfo.source}</td></tr>
+        <tr><td>port</td><td>${addrinfo.port}</td></tr>
+        <tr><td>services</td><td>${addrinfo.services}</td></tr>
+        <tr><td>time</td><td>${addrinfo.time}</td></tr>
+        <tr><td>network</td><td>${addrinfo.network}</td></tr>
         <tr><td>bucket</td><td>${addrinfo.bucket}</td></tr>
         <tr><td>position</td><td>${addrinfo.position}</td></tr>
-        <tr><td>services</td><td>${addrinfo.services}</td></tr>
+        <tr><td>source</td><td>${addrinfo.source}</td></tr>
+        <tr><td>source network</td><td>${addrinfo.source_network}</td></tr>
     </table>`;
 }

--- a/js/main.js
+++ b/js/main.js
@@ -15,7 +15,7 @@ let triedTableState = init_table(
 draw(false, newTableState);
 draw(false, triedTableState);
 
-function processGetAddrmanInfo(getaddrmaninfo) {
+function processGetRawAddrman(addrman) {
   newTableState = init_table(
     NUM_NEW_BUCKETS,
     NEW_HEIGHT,
@@ -30,15 +30,23 @@ function processGetAddrmanInfo(getaddrmaninfo) {
     "#triedCanvasHighlight",
     TRIED_BUCKETS_PER_BUCKET_COLUMN
   );
-  for (const entry of getaddrmaninfo.new_table) {
+
+  for (const bucket_position in addrman.new) {
+    entry = addrman.new[bucket_position];
+    entry["bucket"] = parseInt(bucket_position.split("/")[0]);
+    entry["position"] = parseInt(bucket_position.split("/")[1]);
     newTableState.table[entry.bucket * 64 + entry.position] = entry;
-    newTableState.tree.add(preprocess(entry));
+    newTableState.tree.add(entry);
   }
 
-  for (const entry of getaddrmaninfo.tried_table) {
+  for (const bucket_position in addrman.tried) {
+    entry = addrman.tried[bucket_position];
+    entry["bucket"] = parseInt(bucket_position.split("/")[0]);
+    entry["position"] = parseInt(bucket_position.split("/")[1]);
     triedTableState.table[entry.bucket * 64 + entry.position] = entry;
-    triedTableState.tree.add(preprocess(entry));
+    triedTableState.tree.add(entry);
   }
+
   draw(false, newTableState);
   draw(false, triedTableState);
 }
@@ -46,8 +54,8 @@ function processGetAddrmanInfo(getaddrmaninfo) {
 function loadFromURL(url) {
   fetch(url)
     .then((res) => res.json())
-    .then((getaddrmaninfo) => {
-      processGetAddrmanInfo(getaddrmaninfo);
+    .then((getrawaddrman) => {
+      processGetRawAddrman(getrawaddrman);
     })
     .catch((err) => {
       throw err;
@@ -63,8 +71,8 @@ document.getElementById('selectFiles').addEventListener('change', function(e) {
   if (e.target.files[0]) {
     var fr = new FileReader();
     fr.onload = function (e) {
-      let getaddrmaninfo = JSON.parse(e.target.result);
-      processGetAddrmanInfo(getaddrmaninfo);
+      let getrawaddrman = JSON.parse(e.target.result);
+      processGetRawAddrman(getrawaddrman);
     };
     var files = document.getElementById("selectFiles").files;
 


### PR DESCRIPTION
See https://github.com/bitcoin/bitcoin/pull/28523

New format: 
```
{                                  (json object)
  "table" : {                      (json object) buckets with addresses in the address manager table ( new, tried )
    "bucket/position" : {          (json object) the location in the address manager table (<bucket>/<position>)
      "address" : "str",           (string) The address of the node
      "port" : n,                  (numeric) The port number of the node
      "network" : "str",           (string) The network (ipv4, ipv6, onion, i2p, cjdns) of the address
      "services" : n,              (numeric) The services offered by the node
      "time" : xxx,                (numeric) The UNIX epoch time when the node was last seen
      "source" : "str",            (string) The address that relayed the address to us
      "source_network" : "str"     (string) The network (ipv4, ipv6, onion, i2p, cjdns) of the source address
    },
    ...
  },
  ...
}
```