### PR TITLE
fix: FetchError is never used

### DIFF
--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -5,33 +5,6 @@ use std::{error, io};
 use crate::config::MAX_NAME_LENGTH;
 
 #[derive(Debug)]
-pub enum FetchError {
-    BitcoinCoreRPC(bitcoincore_rpc::Error),
-}
-
-impl fmt::Display for FetchError {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
-            FetchError::BitcoinCoreRPC(e) => write!(f, "Bitcoin Core RPC Error: {}", e),
-        }
-    }
-}
-
-impl error::Error for FetchError {
-    fn source(&self) -> Option<&(dyn error::Error + 'static)> {
-        match *self {
-            FetchError::BitcoinCoreRPC(ref e) => Some(e),
-        }
-    }
-}
-
-impl From<bitcoincore_rpc::Error> for FetchError {
-    fn from(e: bitcoincore_rpc::Error) -> Self {
-        FetchError::BitcoinCoreRPC(e)
-    }
-}
-
-#[derive(Debug)]
 pub enum ConfigError {
     CookieFileDoesNotExist,
     NoBitcoinCoreRpcAuth,


### PR DESCRIPTION
remove it

```
error: enum `FetchError` is never used
 --> src/error.rs:8:10
  |
8 | pub enum FetchError {
  |          ^^^^^^^^^^
  |
note: the lint level is defined here
 --> src/main.rs:1:38
  |
1 | #![cfg_attr(feature = "strict", deny(warnings))]
  |                                      ^^^^^^^^
  = note: `#[deny(dead_code)]` implied by `#[deny(warnings)]`

error: could not compile `proxy` (bin "proxy") due to 1 previous error
```