### PR TITLE
Add config parsing unit tests

### DIFF
--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -22,7 +22,7 @@ struct TomlConfig {
     nodes: Vec<TomlNode>,
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Config {
     pub www_path: PathBuf,
     pub address: SocketAddr,
@@ -54,7 +54,7 @@ impl fmt::Display for TomlNode {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Node {
     pub id: u16,
     pub name: String,
@@ -79,12 +79,8 @@ fn parse_rpc_auth(node_config: &TomlNode) -> Result<Auth, ConfigError> {
     Err(ConfigError::NoBitcoinCoreRpcAuth)
 }
 
-pub fn load_config() -> Result<Config, ConfigError> {
-    let config_file_path =
-        env::var(ENVVAR_CONFIG_FILE).unwrap_or_else(|_| DEFAULT_CONFIG.to_string());
-    info!("Reading configuration file from {}.", config_file_path);
-    let config_string = fs::read_to_string(config_file_path)?;
-    let toml_config: TomlConfig = toml::from_str(&config_string)?;
+pub(crate) fn parse_config(config_string: &str) -> Result<Config, ConfigError> {
+    let toml_config: TomlConfig = toml::from_str(config_string)?;
 
     let mut nodes: BTreeMap<String, Node> = BTreeMap::new();
     for toml_node in toml_config.nodes.iter() {
@@ -129,6 +125,14 @@ pub fn load_config() -> Result<Config, ConfigError> {
     })
 }
 
+pub fn load_config() -> Result<Config, ConfigError> {
+    let config_file_path =
+        env::var(ENVVAR_CONFIG_FILE).unwrap_or_else(|_| DEFAULT_CONFIG.to_string());
+    info!("Reading configuration file from {}.", config_file_path);
+    let config_string = fs::read_to_string(config_file_path)?;
+    parse_config(&config_string)
+}
+
 fn parse_toml_node(toml_node: &TomlNode) -> Result<Node, ConfigError> {
     let node = Node {
         id: toml_node.id,
@@ -138,4 +142,298 @@ fn parse_toml_node(toml_node: &TomlNode) -> Result<Node, ConfigError> {
     };
 
     Ok(node)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn valid_userpass_toml() -> String {
+        r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user"
+            rpc_password = "pass"
+        "#
+        .to_string()
+    }
+
+    // Userpass auth parses correctly; node accessible by both ID and name.
+    #[test]
+    fn test_parse_valid_config_userpass() {
+        let config = parse_config(&valid_userpass_toml()).unwrap();
+        assert_eq!(
+            config.address,
+            SocketAddr::from_str("127.0.0.1:8080").unwrap()
+        );
+        assert_eq!(config.www_path, PathBuf::from("/tmp/www"));
+
+        // Accessible by ID
+        let by_id = config
+            .nodes
+            .get("0")
+            .expect("node should be accessible by id");
+        assert_eq!(by_id.id, 0);
+        assert_eq!(by_id.name, "alice");
+
+        // Accessible by name
+        let by_name = config
+            .nodes
+            .get("alice")
+            .expect("node should be accessible by name");
+        assert_eq!(by_name.id, 0);
+
+        // Auth is UserPass
+        assert!(matches!(by_id.auth, Auth::UserPass(_, _)));
+    }
+
+    // Cookie file auth resolves to Auth::CookieFile when the file exists on disk.
+    #[test]
+    fn test_parse_valid_config_cookie() {
+        let cookie_path = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/test.cookie");
+
+        let toml = format!(
+            r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_cookie_file = "{}"
+            "#,
+            cookie_path
+        );
+
+        let config = parse_config(&toml).unwrap();
+        let node = config.nodes.get("0").unwrap();
+        assert!(matches!(node.auth, Auth::CookieFile(_)));
+    }
+
+    // Two nodes produce 4 BTreeMap entries (id + name key for each).
+    #[test]
+    fn test_parse_multiple_nodes() {
+        let toml = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user1"
+            rpc_password = "pass1"
+            [[nodes]]
+            id = 1
+            name = "bob"
+            rpc_host = "127.0.0.1"
+            rpc_port = 18332
+            rpc_user = "user2"
+            rpc_password = "pass2"
+        "#;
+
+        let config = parse_config(toml).unwrap();
+        assert!(config.nodes.contains_key("0"));
+        assert!(config.nodes.contains_key("alice"));
+        assert!(config.nodes.contains_key("1"));
+        assert!(config.nodes.contains_key("bob"));
+        assert_eq!(config.nodes.len(), 4); // 2 nodes x 2 keys each
+    }
+
+    // Node URL is formatted as http://{host}:{port}.
+    #[test]
+    fn test_node_url_format() {
+        let config = parse_config(&valid_userpass_toml()).unwrap();
+        let node = config.nodes.get("0").unwrap();
+        assert_eq!(node.url, "http://127.0.0.1:8332");
+    }
+
+    // Empty nodes array is rejected.
+    #[test]
+    fn test_parse_no_nodes() {
+        let toml = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            nodes = []
+        "#;
+
+        let err = parse_config(toml).unwrap_err();
+        assert_eq!(err, ConfigError::NoNodes);
+    }
+
+    // Node name exceeding MAX_NAME_LENGTH (32) is rejected.
+    #[test]
+    fn test_parse_name_too_long() {
+        let long_name = "a".repeat(MAX_NAME_LENGTH + 1);
+        let toml = format!(
+            r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "{}"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user"
+            rpc_password = "pass"
+            "#,
+            long_name
+        );
+
+        let err = parse_config(&toml).unwrap_err();
+        assert_eq!(err, ConfigError::NodeNameTooLong);
+    }
+
+    // Node with neither cookie nor user/pass is rejected.
+    #[test]
+    fn test_parse_no_auth() {
+        let toml = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+        "#;
+
+        let err = parse_config(toml).unwrap_err();
+        assert_eq!(err, ConfigError::NoBitcoinCoreRpcAuth);
+    }
+
+    // Nonexistent cookie file path is rejected.
+    #[test]
+    fn test_parse_cookie_file_missing() {
+        let toml = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_cookie_file = "/nonexistent/path/.cookie"
+        "#;
+
+        let err = parse_config(toml).unwrap_err();
+        assert_eq!(err, ConfigError::CookieFileDoesNotExist);
+    }
+
+    // Unparseable SocketAddr is rejected.
+    #[test]
+    fn test_parse_invalid_address() {
+        let toml = r#"
+            address = "not_an_address"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user"
+            rpc_password = "pass"
+        "#;
+
+        let err = parse_config(toml).unwrap_err();
+        assert!(matches!(err, ConfigError::AddrError(_)));
+    }
+
+    // Duplicate node names are rejected.
+    #[test]
+    fn test_parse_duplicate_name_rejected() {
+        let toml = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user1"
+            rpc_password = "pass1"
+            [[nodes]]
+            id = 1
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 18332
+            rpc_user = "user2"
+            rpc_password = "pass2"
+        "#;
+
+        let err = parse_config(toml).unwrap_err();
+        assert!(matches!(err, ConfigError::DuplicateNodeName(ref n) if n == "alice"));
+    }
+
+    // Duplicate node IDs are rejected.
+    #[test]
+    fn test_parse_duplicate_id_rejected() {
+        let toml = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user1"
+            rpc_password = "pass1"
+            [[nodes]]
+            id = 0
+            name = "bob"
+            rpc_host = "127.0.0.1"
+            rpc_port = 18332
+            rpc_user = "user2"
+            rpc_password = "pass2"
+        "#;
+
+        let err = parse_config(toml).unwrap_err();
+        assert!(matches!(err, ConfigError::DuplicateNodeId(0)));
+    }
+
+    // rpc_user without rpc_password (and vice versa) is rejected.
+    #[test]
+    fn test_parse_partial_userpass_rejected() {
+        // user without password
+        let toml_user_only = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_user = "user"
+        "#;
+
+        let err = parse_config(toml_user_only).unwrap_err();
+        assert_eq!(err, ConfigError::NoBitcoinCoreRpcAuth);
+
+        // password without user
+        let toml_pass_only = r#"
+            address = "127.0.0.1:8080"
+            www_path = "/tmp/www"
+            [[nodes]]
+            id = 0
+            name = "alice"
+            rpc_host = "127.0.0.1"
+            rpc_port = 8332
+            rpc_password = "pass"
+        "#;
+
+        let err = parse_config(toml_pass_only).unwrap_err();
+        assert_eq!(err, ConfigError::NoBitcoinCoreRpcAuth);
+    }
+
+    // Malformed TOML string is rejected.
+    #[test]
+    fn test_parse_invalid_toml() {
+        let err = parse_config("this is not valid toml {{{").unwrap_err();
+        assert!(matches!(err, ConfigError::TomlError(_)));
+    }
 }

--- a/proxy/src/config.rs
+++ b/proxy/src/config.rs
@@ -99,7 +99,16 @@ pub fn load_config() -> Result<Config, ConfigError> {
                     );
                     return Err(ConfigError::NodeNameTooLong);
                 }
-                nodes.insert(id.to_string(), node.clone());
+                let id_key = id.to_string();
+                if nodes.contains_key(&id_key) {
+                    error!("Duplicate node id={}.", id);
+                    return Err(ConfigError::DuplicateNodeId(id));
+                }
+                if nodes.contains_key(&name) {
+                    error!("Duplicate node name='{}'.", name);
+                    return Err(ConfigError::DuplicateNodeName(name));
+                }
+                nodes.insert(id_key, node.clone());
                 nodes.insert(name, node);
             }
             Err(e) => {

--- a/proxy/src/error.rs
+++ b/proxy/src/error.rs
@@ -10,9 +10,17 @@ pub enum ConfigError {
     NoBitcoinCoreRpcAuth,
     NoNodes,
     NodeNameTooLong,
+    DuplicateNodeName(String),
+    DuplicateNodeId(u16),
     TomlError(toml::de::Error),
     ReadError(io::Error),
     AddrError(AddrParseError),
+}
+
+impl PartialEq for ConfigError {
+    fn eq(&self, other: &Self) -> bool {
+        std::mem::discriminant(self) == std::mem::discriminant(other)
+    }
 }
 
 impl fmt::Display for ConfigError {
@@ -22,6 +30,8 @@ impl fmt::Display for ConfigError {
             ConfigError::NoBitcoinCoreRpcAuth => write!(f, "please specify a Bitcoin Core RPC .cookie file (option: 'rpc_cookie_file') or a rpc_user and rpc_password"),
             ConfigError::NoNodes => write!(f, "no nodes defined in the configuration"),
             ConfigError::NodeNameTooLong => write!(f, "node name longer than {}", MAX_NAME_LENGTH),
+            ConfigError::DuplicateNodeName(name) => write!(f, "duplicate node name '{}'", name),
+            ConfigError::DuplicateNodeId(id) => write!(f, "duplicate node id {}", id),
             ConfigError::TomlError(e) => write!(f, "the TOML in the configuration file could not be parsed: {}", e),
             ConfigError::ReadError(e) => write!(f, "the configuration file could not be read: {}", e),
             ConfigError::AddrError(e) => write!(f, "the address could not be parsed: {}", e),
@@ -36,6 +46,8 @@ impl error::Error for ConfigError {
             ConfigError::CookieFileDoesNotExist => None,
             ConfigError::NoNodes => None,
             ConfigError::NodeNameTooLong => None,
+            ConfigError::DuplicateNodeName(_) => None,
+            ConfigError::DuplicateNodeId(_) => None,
             ConfigError::TomlError(ref e) => Some(e),
             ConfigError::ReadError(ref e) => Some(e),
             ConfigError::AddrError(ref e) => Some(e),

--- a/proxy/tests/fixtures/test.cookie
+++ b/proxy/tests/fixtures/test.cookie
@@ -1,0 +1,1 @@
+__cookie__:testcookievalue


### PR DESCRIPTION
## Summary

Preliminary work for a more impactful introduction of integration tests.

The proxy has zero tests; CI runs `cargo test` but only catches compilation failures (#52). This adds unit tests
for `config.rs` covering TOML parsing, auth resolution, and validation logic, and fixes two silent data-loss bugs. No Bitcoin Core node required.

## Changes

Bug fix:
- Reject duplicate node names and IDs in `parse_config()` (previously silently overwrote BTreeMap entries)
- Add `DuplicateNodeName` and `DuplicateNodeId` error variants to `ConfigError`

Testing improvements:
- Extract `parse_config()` from `load_config()` to enable testing without filesystem access
- Add `PartialEq` to `ConfigError` (comparison for test assertions)
- Add `Debug` to `Config` and `Node` structs
- Add `tempfile` dev dependency for cookie file tests
- Add `#[cfg(test)]` module with 13 tests:
  - Happy paths: userpass auth, cookie auth, multiple nodes, URL format
  - Error paths: no nodes, name too long, no auth, missing cookie, invalid address, invalid TOML
  - Validation: duplicate name/ID rejected, partial username/pass rejected

## Testing

`cargo test --verbose --all-features` all 13 pass. CI workflow already runs this, no changes needed.