### PR TITLE
build(deps): switch corepc-client from git to crates.io 0.12.0

### DIFF
--- a/proxy/Cargo.lock
+++ b/proxy/Cargo.lock
@@ -205,8 +205,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitreq"
-version = "0.3.1"
-source = "git+https://github.com/rust-bitcoin/corepc#750d68cca667e1b2140a4ca24ddff1c4acdc6ce3"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c84f27ed293cb5218ab015faad9fbb95cf7905865ce71df075c8805a0b33b71"
 dependencies = [
  "serde",
  "serde_json",
@@ -271,8 +272,9 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "corepc-client"
-version = "0.11.0"
-source = "git+https://github.com/rust-bitcoin/corepc#750d68cca667e1b2140a4ca24ddff1c4acdc6ce3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc0d0096927a820ea80d4a43a2355209d9a69ef5b420861bf413c7e667cbff0b"
 dependencies = [
  "bitcoin",
  "corepc-types",
@@ -284,8 +286,9 @@ dependencies = [
 
 [[package]]
 name = "corepc-types"
-version = "0.11.0"
-source = "git+https://github.com/rust-bitcoin/corepc#750d68cca667e1b2140a4ca24ddff1c4acdc6ce3"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1583872320eb2ac629c36753023fd072f1ca1b3b74b20cc62bab055b54278789"
 dependencies = [
  "bitcoin",
  "serde",
@@ -629,7 +632,8 @@ dependencies = [
 [[package]]
 name = "jsonrpc"
 version = "0.19.0"
-source = "git+https://github.com/rust-bitcoin/corepc#750d68cca667e1b2140a4ca24ddff1c4acdc6ce3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "629d2b4ae586d04b6bae3c75879d7ddd39325c2b67a9c87634f4ec88a488dc65"
 dependencies = [
  "base64 0.22.1",
  "bitreq",

--- a/proxy/Cargo.toml
+++ b/proxy/Cargo.toml
@@ -6,8 +6,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-# TODO: Switch to crates.io version once getrawaddrman is included in a release (>= 0.12)
-corepc-client = { git = "https://github.com/rust-bitcoin/corepc", features = ["client-sync"] }
+corepc-client = { version = "0.12.0", features = ["client-sync"] }
 env_logger = "0.11.9"
 log = "0.4.29"
 serde = "1.0.193"


### PR DESCRIPTION
## Summary

Switches `corepc-client` from a git dependency on `rust-bitcoin/corepc` master to the tagged `0.12.0` release on crates.io. The 0.12.0 release is the first tagged release with `getrawaddrman` on the `v30` client. This PR switches the dep accordingly and drops the `Cargo.toml` TODO comment that was tracking the blocker. No source changes are needed, `client_sync::v30::Client` still exposes `get_raw_addrman()` with the same signature.

Closes #50

Note that this supersedes Dependabot PR #74, which only bumps the git ref in `Cargo.lock`..

## Testing

`cargo build` and `cargo test` both pass locally against the crates.io resolution. The migrated build has also been deployed to my production instance and is serving `getrawaddrman` responses with the same shape as the git-pinned build.
